### PR TITLE
[손수림] 1_16 중복문자제거

### DIFF
--- a/sonsurim/1_16.js
+++ b/sonsurim/1_16.js
@@ -1,0 +1,11 @@
+function solution(s) {
+  let answer = '';
+
+  for( let i of s) {
+    if (answer.indexOf(i) === -1) answer += i;
+  }
+
+  return answer;
+}
+
+console.log(solution("ksekksessat"));


### PR DESCRIPTION
## 소요 시간 ⌛️
- 약 2분

## 실행속도 ⏱
```
약 0.032초
```

## 문제에 대한 생각 🧐
- `indexOf`의 동작 형태에 대해 좀 더 자세하게 알 수 있었습니다.
  - `indexOf('k',3)`: 'k'문자열을 3번째 인덱스부터 찾음
- `for문`을 이용해서 본인 인덱스와 해당 문자의 인덱스가 다른 경우 제거하는 패턴은 생각하지 못했어서 신기했습니다!
- 다른 분의 답변을 보니 `includes`를 활용하는 분도 계셨다 참고하면 좋을 것 같습니다.